### PR TITLE
Timestamp in Transfer History is Optional

### DIFF
--- a/schema/query_answer.json
+++ b/schema/query_answer.json
@@ -227,6 +227,14 @@
         },
         "sender": {
           "$ref": "#/definitions/HumanAddr"
+        },
+        "timestamp": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         }
       }
     },

--- a/src/state.rs
+++ b/src/state.rs
@@ -41,7 +41,9 @@ pub struct Tx {
     pub sender: HumanAddr,
     pub receiver: HumanAddr,
     pub coins: Coin,
-    pub timestamp: u64,
+    // This is optional so that the JSON schema reflects that
+    // some SNIP-20 contracts may not include this info.
+    pub timestamp: Option<u64>,
 }
 
 impl Tx {
@@ -52,7 +54,7 @@ impl Tx {
             sender: api.canonical_address(&self.sender)?,
             receiver: api.canonical_address(&self.receiver)?,
             coins: self.coins,
-            timestamp: self.timestamp,
+            timestamp: self.timestamp.unwrap_or(0),
         };
         Ok(tx)
     }
@@ -76,7 +78,7 @@ impl StoredTx {
             sender: api.human_address(&self.sender)?,
             receiver: api.human_address(&self.receiver)?,
             coins: self.coins,
-            timestamp: self.timestamp,
+            timestamp: Some(self.timestamp),
         };
         Ok(tx)
     }


### PR DESCRIPTION
Made the transfer history timestamp an Option so it's not required in the schema.
This should make it so that clients based on the schema can accept responses from contracts that don't provide this info.