### PR TITLE
Transfer history block height

### DIFF
--- a/schema/query_answer.json
+++ b/schema/query_answer.json
@@ -211,6 +211,14 @@
         "sender"
       ],
       "properties": {
+        "block_height": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "coins": {
           "$ref": "#/definitions/Coin"
         },

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -559,7 +559,7 @@ fn try_transfer_impl<S: Storage, A: Api, Q: Querier>(
         &recipient_address,
         amount,
         symbol,
-        env.block.time,
+        env.block
     )?;
 
     Ok(())
@@ -707,7 +707,7 @@ fn try_transfer_from_impl<S: Storage, A: Api, Q: Querier>(
         &recipient_address,
         amount,
         symbol,
-        env.block.time,
+        env.block,
     )?;
 
     Ok(())

--- a/src/state.rs
+++ b/src/state.rs
@@ -41,9 +41,10 @@ pub struct Tx {
     pub sender: HumanAddr,
     pub receiver: HumanAddr,
     pub coins: Coin,
-    // This is optional so that the JSON schema reflects that
-    // some SNIP-20 contracts may not include this info.
+    // The timestamp and block height are optional so that the JSON schema
+    // reflects that some SNIP-20 contracts may not include this info.
     pub timestamp: Option<u64>,
+    pub block_height: Option<u64>,
 }
 
 impl Tx {
@@ -55,6 +56,7 @@ impl Tx {
             receiver: api.canonical_address(&self.receiver)?,
             coins: self.coins,
             timestamp: self.timestamp.unwrap_or(0),
+            block_height: self.block_height.unwrap_or(0),
         };
         Ok(tx)
     }
@@ -68,6 +70,7 @@ pub struct StoredTx {
     pub receiver: CanonicalAddr,
     pub coins: Coin,
     pub timestamp: u64,
+    pub block_height: u64,
 }
 
 impl StoredTx {
@@ -79,6 +82,7 @@ impl StoredTx {
             receiver: api.human_address(&self.receiver)?,
             coins: self.coins,
             timestamp: Some(self.timestamp),
+            block_height: Some(self.block_height),
         };
         Ok(tx)
     }
@@ -91,7 +95,7 @@ pub fn store_transfer<S: Storage>(
     receiver: &CanonicalAddr,
     amount: Uint128,
     denom: String,
-    timestamp: u64,
+    block: cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let mut config = Config::from_storage(store);
     let id = config.tx_count() + 1;
@@ -104,7 +108,8 @@ pub fn store_transfer<S: Storage>(
         sender: sender.clone(),
         receiver: receiver.clone(),
         coins,
-        timestamp,
+        timestamp: block.time,
+        block_height: block.height,
     };
 
     if owner != sender {


### PR DESCRIPTION
This PR adds the block height to the transfer history response.
For now i'm pointing this PR to `optional-transfer-history-timestamp` because i started this branch based on that branch, and i want github to show an accurate diff of what this PR includes.