### PR TITLE
check allowance expiration before increasing or decreasing it

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -303,6 +303,15 @@ pub struct Allowance {
     pub expiration: Option<u64>,
 }
 
+impl Allowance {
+    pub fn is_expired_at(&self, block: &cosmwasm_std::BlockInfo) -> bool {
+        match self.expiration {
+            Some(time) => block.time >= time,
+            None => false, // allowance has no expiration
+        }
+    }
+}
+
 pub fn read_allowance<S: Storage>(
     store: &S,
     owner: &CanonicalAddr,


### PR DESCRIPTION
This PR implements only the bug fix from #16 .

The bug was that if allowance is increased or decreased after the previously provided allowance has expired, then the allowance didn't reset and the new allowance would be added or deducted from the expired allowance.