### PR TITLE
Fixed order of owner and burner in transaction history

### DIFF
--- a/src/transaction_history.rs
+++ b/src/transaction_history.rs
@@ -160,8 +160,8 @@ impl StoredTxAction {
     fn burn(owner: CanonicalAddr, burner: CanonicalAddr) -> Self {
         Self {
             tx_type: TxCode::Burn.to_u8(),
-            address1: Some(owner),
-            address2: Some(burner),
+            address1: Some(burner),
+            address2: Some(owner),
             address3: None,
         }
     }


### PR DESCRIPTION
This bug was reported by @baedrik .

This fixes a bug in transaction history, where when using BurnFrom, the order of burner and owner were accidentally flipped, so if A burned from B, the history would report the opposite.

Do we want to fix this, or just document the mix-up to prevent confusion in the future from conflicting implementations?
(There are already a few live tokens with this code)