### PR TITLE
Fix self transfer duplicate history

### DIFF
--- a/src/transaction_history.rs
+++ b/src/transaction_history.rs
@@ -319,14 +319,19 @@ pub fn store_transfer<S: Storage>(
     };
     let tx = StoredRichTx::from_stored_legacy_transfer(transfer.clone());
 
-    if owner != sender {
+    // Write to the owners history if it's different from the other two addresses
+    if owner != sender && owner != receiver {
         cosmwasm_std::debug_print("saving transaction history for owner");
         append_tx(store, &tx, owner)?;
         append_transfer(store, &transfer, owner)?;
     }
-    cosmwasm_std::debug_print("saving transaction history for sender");
-    append_tx(store, &tx, sender)?;
-    append_transfer(store, &transfer, sender)?;
+    // Write to the sender's history if it's different from the receiver
+    if sender != receiver {
+        cosmwasm_std::debug_print("saving transaction history for sender");
+        append_tx(store, &tx, sender)?;
+        append_transfer(store, &transfer, sender)?;
+    }
+    // Always write to the recipient's history
     cosmwasm_std::debug_print("saving transaction history for receiver");
     append_tx(store, &tx, receiver)?;
     append_transfer(store, &transfer, receiver)?;


### PR DESCRIPTION
Added checks when saving history, making sure history is never recorded twice in the same address's history