### PR TITLE
Query balance with a signed permit instead of a viewing key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "cc"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +371,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +414,24 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -587,7 +622,9 @@ dependencies = [
  "hex",
  "rand_chacha",
  "rand_core",
+ "ripemd160",
  "schemars",
+ "secp256k1",
  "secret-toolkit",
  "serde",
  "sha2 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "snip20-reference-impl"
 version = "0.1.0"
 authors = ["Itzik <itzik@keytango.io>"]
 edition = "2018"
-
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
   "contract.wasm",
@@ -11,7 +10,6 @@ exclude = [
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 
@@ -44,10 +42,11 @@ bincode2 = "2.0.1"
 subtle = { version = "2.2.3", default-features = false }
 base64 = "0.12.3"
 hex = "0.4.2"
-
 rand_chacha = { version = "0.2.2", default-features = false }
-rand_core = { version =  "0.5.1", default-features = false }
+rand_core = { version = "0.5.1", default-features = false }
 sha2 = { version = "0.9.1", default-features = false }
+ripemd160 = "0.9.1"
+secp256k1 = "0.19.0"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.9.2" }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -323,6 +323,10 @@ pub enum QueryMsg {
         address: HumanAddr,
         key: String,
     },
+    BalanceWithPermit {
+        signed: SignedPermit,
+        signature: Signature,
+    },
     TransferHistory {
         address: HumanAddr,
         key: String,
@@ -365,6 +369,7 @@ pub enum QueryAnswer {
         symbol: String,
         decimals: u8,
         total_supply: Option<Uint128>,
+        query_balance_permit_msg: String,
     },
     TokenConfig {
         public_total_supply: bool,
@@ -454,6 +459,59 @@ pub fn space_pad(block_size: usize, message: &mut Vec<u8>) -> &mut Vec<u8> {
     message.reserve(missing);
     message.extend(std::iter::repeat(b' ').take(missing));
     message
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct Signature {
+    pub pub_key: PubKey,
+    pub signature: Binary,
+}
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct PubKey {
+    pub r#type: String, // must be "tendermint/PubKeySecp256k1",
+    pub value: Binary,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct SignedPermit {
+    pub chain_id: String,        // ignored, no Env in query
+    pub account_number: Uint128, // ignored
+    pub sequence: Uint128,       // ignored
+    pub fee: Fee,                // ignored
+    pub msgs: Vec<PermitMsg>,    // the signed message
+    pub memo: String,            // ignored
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct Fee {
+    pub gas: Uint128,
+    pub amount: Vec<Coin>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct Coin {
+    pub denom: String,
+    pub amount: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct PermitMsg {
+    pub r#type: String,
+    pub value: PermitContent,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct PermitContent {
+    pub permit_id: Uint128,
+    pub account: HumanAddr,
+    pub message: String,
 }
 
 #[cfg(test)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -28,6 +28,8 @@ pub const PREFIX_ALLOWANCES: &[u8] = b"allowances";
 pub const PREFIX_VIEW_KEY: &[u8] = b"viewingkey";
 pub const PREFIX_RECEIVERS: &[u8] = b"receivers";
 
+pub const QUERY_BALANCE_PERMIT_MSG: &str = "This signature is a permit to query my balance.";
+
 // Config
 
 #[derive(Serialize, Debug, Deserialize, Clone, PartialEq, JsonSchema)]
@@ -47,6 +49,7 @@ pub struct Constants {
     pub mint_is_enabled: bool,
     // is burn enabled
     pub burn_is_enabled: bool,
+    pub query_balance_permit_msg: String,
 }
 
 pub struct ReadonlyConfig<'a, S: ReadonlyStorage> {


### PR DESCRIPTION
Usage example:

```js
 const permit = await window.keplr.signAmino(chainId, myAddress, {
    chain_id: chainId,
    account_number: "0",
    sequence: "0",
    fee: {
      amount: [{ denom: "uscrt", amount: "0" }],
      gas: "1",
    },
    msgs: [
      {
        type: "query_balance_permit",
        value: { permit_id: "0", account: myAddress, message: "This signature is a permit to query my balance." },
      },
    ],
    memo: "",
  });

  const { amount } = secretjs.queryContractSmart(mySnip20Token, permit);
```